### PR TITLE
fix: ショップの一覧ページと詳細ページのマップJSを切り分け

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -26,7 +26,6 @@ class ShopsController < ApplicationController
 
   def show
     @shop = Shop.find(params[:id])
-    set_map_data(@shop.latitude, @shop.longitude, [@shop])
   end
 
   private

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -23,8 +23,6 @@
       </div>
       <div class="md:w-1/3">
         <div id="map" class="w-full h-64 md:h-full rounded-xl"></div>
-        <%= javascript_include_tag "google_maps" %>
-        <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['API_KEY'] %>&callback=initMap" async defer></script>
       </div>
     </div>
 
@@ -43,3 +41,18 @@
     </div>
   </div>
 </div>
+
+<script>
+function initMap() {
+  var shopLocation = {lat: <%= @shop.latitude %>, lng: <%= @shop.longitude %>};
+  var map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 15,
+    center: shopLocation
+  });
+  var marker = new google.maps.Marker({
+    position: shopLocation,
+    map: map
+  });
+}
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['API_KEY'] %>&callback=initMap" async defer></script>


### PR DESCRIPTION
# 内容
・詳細ページに不必要なボタンが表示される
・ショップ一覧ページから詳細ページへ飛んで、一覧ページへ戻った時に、ピンが正しく表示されない
以上のことから、ショップの一覧ページと詳細ページのマップJSを切り分け

close #49 