### PR TITLE
fix: ブックマーク削除方法の変更

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -16,10 +16,9 @@ class BookmarksController < ApplicationController
     shop = Shop.find(params[:shop_id])
 
     if bookmark_list.shops.destroy(shop)
-      redirect_to bookmark_list_path(bookmark_list), success: '削除しました'
+      render json: { success: true, name: bookmark_list.name }
     else
-      flash.now[:error] = '削除に失敗しました'
-      render template: 'bookmark_list/show'
+      render json: { success: false, errors: bookmark_list.errors.full_messages }
     end
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -16,7 +16,8 @@ class BookmarksController < ApplicationController
     shop = Shop.find(params[:shop_id])
 
     if bookmark_list.shops.destroy(shop)
-      render json: { success: true, name: bookmark_list.name }
+      other_bookmarks_exist = Bookmark.user_bookmarked_shop?(current_user, shop) ? true : false
+      render json: { success: true, name: bookmark_list.name, other_bookmarks_exist: other_bookmarks_exist }
     else
       render json: { success: false, errors: bookmark_list.errors.full_messages }
     end

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -41,7 +41,7 @@ export default class extends Controller {
       .then(data => {
         if (data.success) {
           this.setFlashMessage("success", `${data.name}へ保存しました`);
-          this.updateBookmarkButton();
+          this.updateBookmarkButton(true);
         } else {
           this.setFlashMessage("error", `すでに保存しています`);
         }
@@ -78,6 +78,8 @@ export default class extends Controller {
       .then(data => {
         if (data.success) {
           this.setFlashMessage("success", `${data.name}から削除しました`);
+          const otherBookmarksExist = data.other_bookmarks_exist;
+          this.updateBookmarkButton(otherBookmarksExist);
         } else {
           this.setFlashMessage("error", `すでに削除されています`);
         }
@@ -128,8 +130,8 @@ export default class extends Controller {
     }
   }
 
-  updateBookmarkButton() {
+  updateBookmarkButton(bookmarked) {
     const bookmarkButton = document.querySelector(`.bookmark-icon[data-shop-id="${shopId}"]`);
-    bookmarkButton.innerHTML = '<i class="fas fa-bookmark w-7 h-7 text-yellow-500"></i>';
+    bookmarkButton.innerHTML = bookmarked ? '<i class="fas fa-bookmark w-7 h-7 text-yellow-500"></i>' : '<i class="fas fa-bookmark w-7 h-7 text-gray-300"></i>';
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
     this.myModalTarget.classList.remove('hidden');
   }
 
-  close(event) {
+  closeBookmark(event) {
     const clickedList = event.currentTarget;
     const listId = clickedList.getAttribute("data-list-id");
 
@@ -44,6 +44,42 @@ export default class extends Controller {
           this.updateBookmarkButton();
         } else {
           this.setFlashMessage("error", `すでに保存しています`);
+        }
+      })
+      .catch(error => {
+        console.error("リクエストエラー", error);
+        this.setFlashMessage("error", "リクエストエラーが発生しました");
+      });
+    }
+    this.backGroundTarget.classList.add("hidden");
+  }
+
+  closeUnbookmark(event) {
+    const clickedList = event.currentTarget;
+    const listId = clickedList.getAttribute("data-list-id");
+
+    if (shopId && listId) {
+      const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+      fetch(`/bookmarks/${listId}?shop_id=${shopId}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+      })
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new Error('サーバーエラー');
+        }
+      })
+      .then(data => {
+        if (data.success) {
+          this.setFlashMessage("success", `${data.name}から削除しました`);
+        } else {
+          this.setFlashMessage("error", `すでに削除されています`);
         }
       })
       .catch(error => {

--- a/app/javascript/google_maps.js
+++ b/app/javascript/google_maps.js
@@ -71,6 +71,8 @@ window.initMap = function() {
         },
         function(error) {
           console.error("位置情報の取得に失敗しました: " + error.message);
+          alert('お使いのブラウザでは位置情報がサポートされていません')
+          window.location.href = `/home`
         }
       );
     } else {

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,6 +4,10 @@ class Bookmark < ApplicationRecord
 
   validates :bookmark_list_id, uniqueness: { scope: :shop_id }
 
+  def self.bookmark_list_present?(shop, list)
+    find_by(shop: shop, bookmark_list: list).present?
+  end
+
   def self.user_bookmarked_shop?(user, shop)
     user.present? && find_by(shop: shop, bookmark_list: user.bookmark_lists)
   end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,7 +4,7 @@ class Bookmark < ApplicationRecord
 
   validates :bookmark_list_id, uniqueness: { scope: :shop_id }
 
-  def self.find_by_shop(shop)
-    find_by(shop: shop)
+  def self.user_bookmarked_shop?(user, shop)
+    user.present? && find_by(shop: shop, bookmark_list: user.bookmark_lists)
   end
 end

--- a/app/views/bookmark_lists/index.html.erb
+++ b/app/views/bookmark_lists/index.html.erb
@@ -6,17 +6,10 @@
         <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->modal#closeModal"></i>
       </div>
       <% @bookmark_lists.each do |list| %>
-        <% if Bookmark.find_by(shop: @shop, bookmark_list: list) %>
-          <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#closeUnbookmark" data-list-id="<%= list.id %>">
-          <input type="checkbox" class="mr-2" checked>
+        <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#<%= Bookmark.bookmark_list_present?(@shop, list) ? 'closeUnbookmark' : 'closeBookmark' %>" data-list-id="<%= list.id %>">
+          <input type="checkbox" class="mr-2" <%= 'checked' if Bookmark.bookmark_list_present?(@shop, list) %>>
           <button><%= list.name %></button>
-          </div>
-        <% else %>
-          <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#closeBookmark" data-list-id="<%= list.id %>">
-          <input type="checkbox" class="mr-2">
-          <button><%= list.name %></button>
-          </div>
-        <% end %>
+        </div>
       <% end %>
       <div class="flex justify-center border-b pb-2">
         <i class="fa-solid fa-plus mt-1 mr-2"></i>

--- a/app/views/bookmark_lists/index.html.erb
+++ b/app/views/bookmark_lists/index.html.erb
@@ -6,10 +6,17 @@
         <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->modal#closeModal"></i>
       </div>
       <% @bookmark_lists.each do |list| %>
-        <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#close" data-list-id="<%= list.id %>">
-        <input type="checkbox" class="mr-2" <%= "checked" if Bookmark.find_by(shop: @shop, bookmark_list: list) %>>
-        <button><%= list.name %></button>
-        </div>
+        <% if Bookmark.find_by(shop: @shop, bookmark_list: list) %>
+          <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#closeUnbookmark" data-list-id="<%= list.id %>">
+          <input type="checkbox" class="mr-2" checked>
+          <button><%= list.name %></button>
+          </div>
+        <% else %>
+          <div class="flex justify-center mb-5 border-b pb-2 list-button" data-action="click->modal#closeBookmark" data-list-id="<%= list.id %>">
+          <input type="checkbox" class="mr-2">
+          <button><%= list.name %></button>
+          </div>
+        <% end %>
       <% end %>
       <div class="flex justify-center border-b pb-2">
         <i class="fa-solid fa-plus mt-1 mr-2"></i>

--- a/app/views/bookmark_lists/show.html.erb
+++ b/app/views/bookmark_lists/show.html.erb
@@ -18,12 +18,20 @@
               <%= link_to shop.name, shop_path(shop), class: 'text-xl font-semibold hover:text-yellow-500' %>
               <p class="text-sm md:text-base text-gray-600 mt-2 mb-2"><%= shop.address %></p>
               <p class="text-sm md:text-base text-gray-600 mb-2"><%= shop.phone_number %></p>
-              <a href="https://www.google.com/maps/search/?api=1&query=<%= shop.name %>&query_place_id=<%= shop.place_id %>" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:border-b hover:border-yellow-500 hover:text-yellow-500">
-                <i class="fas fa-location-dot mr-2"></i>
-                GoogleMap
+              <a href="https://www.google.com/maps/dir/?api=1&destination=<%= shop.name %>&destination_place_id=<%= shop.place_id %>" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:border-b hover:border-yellow-500 hover:text-yellow-500">
+                <i class="fas fa-route mr-2"></i>
+                経路案内
               </a>
-              <%= link_to "削除", bookmark_path(shop_id: shop),  data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: 'w-20 h-12 btn bg-red-500 hover:bg-red-600 text-white absolute bottom-5 right-5' %>
             </div>
+            <% if user_signed_in? %>
+              <a href="/bookmark_lists?shop_id=<%= shop.id %>" data-turbo-frame="modal" class="absolute top-1 right-1 bookmark-icon" data-shop-id="<%= shop.id %>">
+                <% if Bookmark.user_bookmarked_shop?(current_user, shop) %>
+                  <i class="fas fa-bookmark w-7 h-7 text-yellow-500"></i>
+                <% else %>
+                  <i class="fas fa-bookmark w-7 h-7 text-gray-300"></i>
+                <% end %>
+              </a>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/shops/_shop.html.erb
+++ b/app/views/shops/_shop.html.erb
@@ -17,10 +17,10 @@
     </div>
     <% if user_signed_in? %>
       <a href="/bookmark_lists?shop_id=<%= shop.id %>" data-turbo-frame="modal" class="absolute top-1 right-1 bookmark-icon" data-shop-id="<%= shop.id %>">
-        <% if Bookmark.find_by_shop(shop) %>
+        <% if Bookmark.user_bookmarked_shop?(current_user, shop) %>
           <i class="fas fa-bookmark w-7 h-7 text-yellow-500"></i>
         <% else %>
-          <i class="far fa-bookmark w-7 h-7"></i>
+          <i class="fas fa-bookmark w-7 h-7 text-gray-300"></i>
         <% end %>
       </a>
     <% end %>


### PR DESCRIPTION
# 内容
・マイページのリスト詳細の削除ボタンからでしかブックマークを削除できなかったが、ブックマークボタンからどこでも削除できるように変更
・位置情報が取得できなかった場合にユーザーへ知らせ、画面をリロードするよう修正
・他のアカウントがブックマークしたものもブックマーク表示されるバグを修正

close #53
close #54 