### PR TITLE
fix: ブックマークボタンをログイン時のみの表示に修正

### DIFF
--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -4,7 +4,9 @@
       <div class="card-body md:w-2/3 pt-5" data-controller="modal">
         <div class="flex items-center justify-between">
           <h1 class="text-3xl font-bold underline mb-4"><%= @shop.name %></h1>
-          <%= render 'bookmark_icon', shop: @shop %>
+          <% if user_signed_in? %>
+            <%= render 'bookmark_icon', shop: @shop %>
+          <% end %>
         </div>
         <p class="text-lg"><span class="font-semibold"><%= t('.address') %>：</span><%= @shop.address %></p>
         <p class="text-lg"><span class="font-semibold"><%= t('.phone_number') %>：</span><%= @shop.phone_number %></p>


### PR DESCRIPTION
# 内容
- ショップ詳細画面において、ログアウト中もブックマークボタンが表示されていたため修正
- トップページの画像を圧縮